### PR TITLE
Update BardCookies to allow any cookies (Fixes #50)

### DIFF
--- a/bardapi/core_cookies.py
+++ b/bardapi/core_cookies.py
@@ -26,7 +26,7 @@ class BardCookies:
         Initialize the Bard instance.
 
         Args:
-            cookie_dict (dic): Bard cookies.
+            cookie_dict (dict): Bard cookies.
             timeout (int): Request timeout in seconds.
             proxies (dict): Proxy configuration for requests.
             session (requests.Session): Requests session object.
@@ -44,7 +44,7 @@ class BardCookies:
             self.session = requests.Session()
             self.session.headers = SESSION_HEADERS
 
-            for k, v in self.cookie_dict:
+            for k, v in self.cookie_dict.items():
                 self.session.cookies.set(k, v)
         else:
             self.session = session

--- a/bardapi/core_cookies.py
+++ b/bardapi/core_cookies.py
@@ -178,10 +178,6 @@ class BardCookies:
         Raises:
             Exception: If the __Secure-1PSID value is invalid or SNlM0e value is not found in the response.
         """
-        if not self.token or self.token[-1] != ".":
-            raise Exception(
-                "__Secure-1PSID value must end with a single dot. Enter correct __Secure-1PSID value."
-            )
         resp = self.session.get(
             "https://bard.google.com/", timeout=self.timeout, proxies=self.proxies
         )

--- a/bardapi/core_cookies.py
+++ b/bardapi/core_cookies.py
@@ -15,7 +15,6 @@ class BardCookies:
 
     def __init__(
         self,
-        token: str = None,
         cookie_dict: dict = None,
         timeout: int = 20,
         proxies: dict = None,
@@ -27,14 +26,13 @@ class BardCookies:
         Initialize the Bard instance.
 
         Args:
-            token (str): Bard API token.
+            cookie_dict (dic): Bard cookies.
             timeout (int): Request timeout in seconds.
             proxies (dict): Proxy configuration for requests.
             session (requests.Session): Requests session object.
             language (str): Language code for translation (e.g., "en", "ko", "ja").
         """
-        self.token = token or os.getenv("_BARD_API_KEY")
-        self.cookie_dict = cookie_dict or None
+        self.cookie_dict = cookie_dict
         self.proxies = proxies
         self.timeout = timeout
         self._reqid = int("".join(random.choices(string.digits, k=4)))
@@ -45,14 +43,9 @@ class BardCookies:
         if session is None:
             self.session = requests.Session()
             self.session.headers = SESSION_HEADERS
-            if self.token is not None:
-                self.session.cookies.set("__Secure-1PSID", self.token)
-            else:
-                self.session.cookies.set(
-                    "__Secure-1PSID", self.cookie_dict["__Secure-1PSID"]
-                )
-            self.session.cookies.set("APISID", self.cookie_dict["APISID"])
-            self.session.cookies.set("SAPISID", self.cookie_dict["SAPISID"])
+
+            for k, v in self.cookie_dict:
+                self.session.cookies.set(k, v)
         else:
             self.session = session
         self.SNlM0e = self._get_snim0e()


### PR DESCRIPTION
THIS PROJECT IS IN MAINTENANCE MODE. We accept pull requests for Bug Fixes **ONLY**. NO NEW FEATURES ACCEPTED!

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update BardCookies to remove hard-coded cookies assigns and allow any cookies by iterating dict.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#50  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix for #50

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```py
from bardapi import BardCookies

cookie_dict = {
    "__Secure-1PSID": "...",
    "__Secure-1PSIDTS": "...",
}

bard = BardCookies(cookie_dict=cookie_dict)

print(bard.get_answer("こんにちは"))
```

## Screenshots (if appropriate):

