### PR TITLE
Include conversation_id in params

### DIFF
--- a/bardapi/core.py
+++ b/bardapi/core.py
@@ -19,6 +19,7 @@ class Bard:
         timeout: int = 20,
         proxies: dict = None,
         session: requests.Session = None,
+        conversation_id: str = None,
         language: str = None,
         run_code: bool = False,
     ):
@@ -29,6 +30,7 @@ class Bard:
             token (str): Bard API token.
             timeout (int): Request timeout in seconds.
             proxies (dict): Proxy configuration for requests.
+            conversation_id: ID to fetch conversational context
             session (requests.Session): Requests session object.
             language (str): Language code for translation (e.g., "en", "ko", "ja").
         """
@@ -39,6 +41,8 @@ class Bard:
         self.conversation_id = ""
         self.response_id = ""
         self.choice_id = ""
+        if conversation_id != None:
+            self.conversation_id = conversation_id
         # Set session
         if session is None:
             self.session = requests.Session()


### PR DESCRIPTION
Include Conversation ID

THIS PROJECT IS IN MAINTENANCE MODE. We accept pull requests for Bug Fixes **ONLY**. NO NEW FEATURES ACCEPTED!

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I modified the init function in the Bard class to allow a conversation_id parameter to be passed. Its only purpose is to assign the conversation_id attribute of the class to a specified value prior to calling the get_answer function.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/dsdanielpark/Bard-API/issues/32
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I found through local experimentation that this was necessary in order to actually get conversational context. Just reusing the session object on its own didn't seem to be achieving that result.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I am running the package in a back end FastAPI application locally with a Flutter Linux app for a front end. To test the context, I began by asking a pair of related questions to the official Bard site. This was my control for what a working, context-aware response looked like. I then used my API to ask the same two questions with the same session reuse pattern suggested in the readme. While I was able to get responses, they did not match the context-aware responses from the official site and the second answer didn't indicate awareness of the first question. However, after making the proposed changes to my local instance of the module, I was able to exactly reproduce the context-aware responses generated by the official site. 
## Screenshots (if appropriate):
test context prompt
![image](https://github.com/dsdanielpark/Bard-API/assets/122550660/494fdc49-e34a-441a-a59f-0499d3d8cb1e)

context-aware control response
![image](https://github.com/dsdanielpark/Bard-API/assets/122550660/785ac07b-f2eb-440c-8dc3-fac7e430d2be)

result when only reusing the session object
![image](https://github.com/dsdanielpark/Bard-API/assets/122550660/60b6b68e-0de5-409e-a147-72e1c170e92a)

result after implementing proposed changes
![image](https://github.com/dsdanielpark/Bard-API/assets/122550660/861fc396-3b70-486e-9cbb-4c0f5471fac4)



