### PR TITLE
feat: browser auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 deep_translator
 colorama
 httpx[http2]
+browser-cookie3


### PR DESCRIPTION
Add option to get session `token` from browsers automatically.
Using [browser_cookie3](https://github.com/borisbabic/browser_cookie3) we extract the `__Secure-1PSID` cookie from all browsers, and then we can use the `API` without passing the `token` 

It's cross platform so it works across all browsers and all platforms.

## How Has This Been Tested?
Tested on Windows 10 with `Chrome` / `Brave`

## Usage
```python
from bardapi import Bard

bard = Bard(token_from_browser=True)
res = bard.get_answer('Do you like cookies?')
print(res)
```
