### PR TITLE
Feat/analyze image

### DIFF
--- a/bardapi/core.py
+++ b/bardapi/core.py
@@ -332,7 +332,7 @@ class Bard:
 
         Args:
             input_text (str): Input text for the query.
-            image (bytes): Input image bytes for the query
+            image (bytes): Input image bytes for the query, support image types: jpeg, png, webp
 
         Returns:
             dict: Answer from the Bard API in the following format:

--- a/bardapi/core.py
+++ b/bardapi/core.py
@@ -9,6 +9,7 @@ from google.cloud import translate_v2 as translate
 from bardapi.constants import ALLOWED_LANGUAGES, SESSION_HEADERS
 import base64
 import browser_cookie3
+import uuid
 
 class Bard:
     """
@@ -277,6 +278,135 @@ class Bard:
         audio_b64 = resp_json[0]
         audio_bytes = base64.b64decode(audio_b64)
         return audio_bytes
+
+    def _upload_image(self, image: bytes, filename = 'Photo.jpg'):
+        """
+        Upload image into bard bucket on Google API
+
+        Returns:
+            str: relative URL of image.
+        """
+        resp = requests.options('https://content-push.googleapis.com/upload/')
+        resp.raise_for_status()
+        size = len(image)
+
+        headers = {
+            'authority': 'content-push.googleapis.com',
+            'accept': '*/*',
+            'accept-language': 'en-US,en;q=0.7',
+            'authorization': 'Basic c2F2ZXM6cyNMdGhlNmxzd2F2b0RsN3J1d1U=', # constant authorization key
+            'content-type': 'application/x-www-form-urlencoded;charset=UTF-8',
+            'origin': 'https://bard.google.com',
+            'push-id': 'feeds/mcudyrk2a4khkz', # constant
+            'referer': 'https://bard.google.com/',
+            'x-goog-upload-command': 'start',
+            'x-goog-upload-header-content-length': str(size),
+            'x-goog-upload-protocol': 'resumable',
+            'x-tenant-id': 'bard-storage',
+        }
+
+        data = 'File name: Photo.jpg'
+        resp = requests.post('https://content-push.googleapis.com/upload/', headers=headers, data=data)
+        resp.raise_for_status()
+        upload_url = resp.headers['X-Goog-Upload-Url']
+        resp = requests.options(upload_url, headers=headers)
+        resp.raise_for_status()
+        headers['x-goog-upload-command'] = 'upload, finalize'
+
+        # It can be that we need to check returned offset
+        headers['X-Goog-Upload-Offset'] = '0'
+        resp = requests.post(upload_url, headers=headers, data=image)
+        resp.raise_for_status()
+        return resp.text
+
+
+    def analyze_image(self, input_text: str, image: bytes, lang = 'en-GB', filename = 'Photo.jpg') -> dict:
+        """
+        Send Bard image along with question and get answer
+
+        Example:
+        >>> token = 'xxxxxxxxxx'
+        >>> bard = Bard(token=token)
+        >>> image = open('image.jpg', 'rb').read()
+        >>> bard_answer = bard.analyze_image("what is in the image?", image)
+
+        Args:
+            input_text (str): Input text for the query.
+            image (bytes): Input image bytes for the query
+
+        Returns:
+            dict: Answer from the Bard API in the following format:
+                {
+                    "content": str,
+                    "conversation_id": str,
+                    "response_id": str,
+                    "factualityQueries": list,
+                    "textQuery": str,
+                    "choices": list,
+                    "links": list,
+                    "imgaes": set,
+                    "code": str
+                }
+        """
+
+        # jpeg, png, webp
+        image_url = self._upload_image(image)
+
+        input_data_struct = [
+            None,
+            [
+                [input_text, 0, None, [[[image_url, 1], filename]]], [lang], ['', '', ''],
+                '', # Unknown random string value (1000 characters +)
+                uuid.uuid4().hex, # should be random uuidv4 (32 characters)
+                None, [1] ,0 , [], []
+            ]
+        ]
+        params = {
+            "bl": "boq_assistant-bard-web-server_20230419.00_p1",
+            "_reqid": str(self._reqid),
+            "rt": "c",
+        }
+
+        input_data_struct[1] = json.dumps(input_data_struct[1])
+        data = {
+            "f.req": json.dumps(input_data_struct),
+            "at": self.SNlM0e,
+        }
+
+        resp = self.session.post(
+            'https://bard.google.com/u/1/_/BardChatUi/data/assistant.lamda.BardFrontendService/StreamGenerate',
+            params=params,
+            data=data,
+        )
+        # Post-processing of response
+        resp_dict = json.loads(resp.content.splitlines()[3])[0][2]
+        if not resp_dict:
+            return {
+                "content": f"Response Error: {resp.content}. "
+                           f"\nTemporarily unavailable due to traffic or an error in cookie values. "
+                           f"Please double-check the cookie values and verify your network environment."
+            }
+        parsed_answer = json.loads(resp_dict)
+
+        # Returnd dictionary object
+        bard_answer = {
+            "content": parsed_answer[4][0][1][0],
+            "conversation_id": parsed_answer[1][0],
+            "response_id": parsed_answer[1][1],
+            "factualityQueries": parsed_answer[3],
+            "textQuery": parsed_answer[2][0] if parsed_answer[2] else "",
+            "choices": [{"id": x[0], "content": x[1]} for x in parsed_answer[4]],
+            "links": self._extract_links(parsed_answer[4]),
+            "images": [""],
+            "code": "",
+        }
+        self.conversation_id, self.response_id, self.choice_id = (
+            bard_answer["conversation_id"],
+            bard_answer["response_id"],
+            bard_answer["choices"][0]["id"],
+        )
+        self._reqid += 100000
+        return bard_answer
 
     def export_conversation(self, bard_answer, title: str = ''):
         """


### PR DESCRIPTION
Add the ability to send image along with question and let bard analyze it and answer on it

## Description
Bard as the option to send image and ask about it, this feature add this feature

## How Has This Been Tested?
Tested manually with different images and different accounts

## Additional info
Currenly bard support response for this only in english

## Usage
```python
from bardapi import Bard

bard = Bard(token = '...')
image = open('image.jpg', 'rb').read() # jpeg, png, webp are supported
bard_answer = bard.analyze_image('What is in the image?', image)
```
