### PR TITLE
forced header to "start" to allow multiple image uploads to URL

### DIFF
--- a/bardapi/core.py
+++ b/bardapi/core.py
@@ -292,6 +292,7 @@ class Bard:
 
         headers = IMG_UPLOAD_HEADERS
         headers['size'] = str(size)
+        headers['x-goog-upload-command'] = 'start'
 
         data = 'File name: Photo.jpg'
         resp = requests.post('https://content-push.googleapis.com/upload/', headers=headers, data=data)


### PR DESCRIPTION
There is an issue with uploading multiple images with `ask_about_image` because the header `x-goog-upload-command` in the `_upload_image` function has value `upload, finalize` after first post request (it never gets changed back to `start`). This change forces the header to `start` prior to all post requests, allowing multiple image uploads.

## Description
Added line `headers['x-goog-upload-command'] = 'start'` prior to sending a post request to `https://content-push.googleapis.com/upload/`, allowing a request regardless of the current value of the header. Value of header prior to first call is `start` as initialized in `constants.py`, and after the first call is `upload, finalize`. Header `x-goog-upload-command` is being changed in the `_upload_image` function, which `ask_about_image` calls and where error originally occurred. 

## Related Issue
- Bug fix
- Issue https://github.com/dsdanielpark/Bard-API/issues/112 (closed)
- Solution provided by user [elinalai0000](https://github.com/elinalai0000)

## Motivation and Context
Allows for multiple image uploads without needing to restart the script. Creating new objects of class Bard did not resolve issue. Allows for easy consecutive image uploads without running multiple shell processes. 

## How Has This Been Tested?
- Linux machine, United States.
- Multiple image uploads with varying images and prompts were tested and verified through output and by visiting https://bard.google.com/ to check upload history
- No impact on other areas of code, as only the `x-goog-upload-command` header was changed, which gets manipulated later by the same function to `upload` and then `finalize` regardless of previous header value. No other parts of code use this header. Changed only directly prior to post request.

## Screenshots
[image](https://cdn.discordapp.com/attachments/953870034227302470/1130988819290804294/bugfixbardapi.png)