### PR TITLE
fix: do not print in async ask, change it to the same logic as sync ask

### DIFF
--- a/bardapi/core_async.py
+++ b/bardapi/core_async.py
@@ -186,7 +186,6 @@ class BardAsync:
             # TODO:
             #  handle exception using logging instead
             code = None
-            print(f"Unable to parse answer from the response: {e}")
 
         # Returned dictionary object
         bard_answer = {


### PR DESCRIPTION
Maybe let the logic same as sync mode.
because not all the answers have `code block`
e.g. seems the error message will confuse users.

`Unable to parse answer from the response: list index out of range`