### PR TITLE
feat: export code to replit

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ $ pip install git+https://github.com/dsdanielpark/Bard-API.git
 - [Get image links](https://github.com/dsdanielpark/Bard-API/blob/main/README_DEV.md#get-image-links)
 - [ChatBard](https://github.com/dsdanielpark/Bard-API/blob/main/README_DEV.md#chatbard)
 - [Export Conversation](https://github.com/dsdanielpark/Bard-API/blob/main/README_DEV.md#export-conversation)
+- [Export Code to Repl.it](https://github.com/dsdanielpark/Bard-API/blob/main/README_DEV.md#export-code-to-replit)
 - [Executing Python code received as a response from Bard](https://github.com/dsdanielpark/Bard-API/blob/main/README_DEV.md#chatbard)
 - [Using Bard Asynchronously](https://github.com/dsdanielpark/Bard-API/blob/main/README_DEV.md#using-bard-asynchronously)
 - [Bard Cookies](https://github.com/dsdanielpark/Bard-API/blob/main/README_DEV.md#bard-which-can-get-cookies)

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -18,6 +18,7 @@ pip install git+https://github.com/dsdanielpark/Bard-API.git
     - [Get image links](#get-image-links)
     - [ChatBard](#chatbard)
     - [Export Conversation](#export-conversation)
+    - [Export Code Repl.it](#export-code-replit)
     - [Executing Python code received as a response from Bard](#executing-python-code-received-as-a-response-from-bard)
     - [Using Bard asynchronously](#using-bard-asynchronously)
     - [Multi-cookie Bard](#multi-cookie-bard)
@@ -167,6 +168,17 @@ print(url)
 ```
 
 <br>
+
+### Export Code Repl.it
+```python
+from bardapi import Bard
+
+bard = Bard(token='...')
+
+bard_code = bard.get_answer('code python for print hello world')
+url = bard.export_code(bard_code) # print('Hello World!')
+print(url) # https://replit.com/external/v1/claims/xxx/claim
+```
 
 ### Executing Python code received as a response from Bard
 ```python

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -18,7 +18,7 @@ pip install git+https://github.com/dsdanielpark/Bard-API.git
     - [Get image links](#get-image-links)
     - [ChatBard](#chatbard)
     - [Export Conversation](#export-conversation)
-    - [Export Code Repl.it](#export-code-replit)
+    - [Export Code to Repl.it](#export-code-to-replit)
     - [Executing Python code received as a response from Bard](#executing-python-code-received-as-a-response-from-bard)
     - [Using Bard asynchronously](#using-bard-asynchronously)
     - [Multi-cookie Bard](#multi-cookie-bard)
@@ -169,14 +169,18 @@ print(url)
 
 <br>
 
-### Export Code Repl.it
+### Export Code to Repl.it
 ```python
 from bardapi import Bard
 
 bard = Bard(token='...')
 
-bard_code = bard.get_answer('code python for print hello world')
-url = bard.export_code(bard_code) # print('Hello World!')
+bard_answer = bard.get_answer("code python to print hello world")
+# {'code': 'print("Hello World")', 'langCode': 'python'}
+url = bard.export_replit(
+    code=bard_answer['code'],
+    langcode=bard_answer['langCode'],
+)
 print(url) # https://replit.com/external/v1/claims/xxx/claim
 ```
 

--- a/bardapi/core.py
+++ b/bardapi/core.py
@@ -195,11 +195,12 @@ class Bard:
                 for x in parsed_answer[4]
             ]
 
-        # Get code (optional)
+        # Get langcode & code (optional)
         try:
-            code = parsed_answer[4][0][1][0].split("```")[1][6:]
+            langcode = parsed_answer[4][0][1][0].split("```")[1].split("\n")[0].strip()
+            code = parsed_answer[4][0][1][0].split("```")[1][len(langcode) :]
         except Exception:
-            code = None
+            langcode, code = None, None
 
         # Returnd dictionary object
         bard_answer = {
@@ -211,6 +212,7 @@ class Bard:
             "choices": [{"id": x[0], "content": x[1]} for x in parsed_answer[4]],
             "links": self._extract_links(parsed_answer[4]),
             "images": images,
+            "langCode": langcode,
             "code": code,
         }
         self.conversation_id, self.response_id, self.choice_id = (
@@ -481,19 +483,23 @@ class Bard:
         self._reqid += 100000
         return url
 
-    def export_replit(self, code: str, filename: str = "main.py", **kwargs):
+    def export_replit(
+        self, code: str, langcode: str = None, filename: str = None, **kwargs
+    ):
         """
         Get Export URL to repl.it from code
 
         Example:
         >>> token = 'xxxxxxxxxx'
         >>> bard = Bard(token=token)
-        >>> bard_code = bard.get_answer("make python code to print hello world")['code']
-        >>> url = bard.export_replit(bard_code, filename="main.py") # python code
+        >>> bard_answer = bard.get_answer("code python to print hello world")
+        >>> url = bard.export_replit(bard_answer['code'], bard_answer['langCode'])
 
         Args:
-            code (str): code to export
+            code (str): source code
+            langcode (str): code language
             filename (str): filename for code language
+            **kwargs: instructions, source_path
         Returns:
             string: export URL to create repl
         """
@@ -504,11 +510,45 @@ class Bard:
             "_reqid": str(self._reqid),
             "rt": "c",
         }
+        # refference: https://github.com/jincheng9/markdown_supported_languages
+        support_langs = {
+            "python": "main.py",
+            "javascript": "index.js",
+            "go": "main.go",
+            "java": "Main.java",
+            "kotlin": "Main.kt",
+            "php": "index.php",
+            "c#": "main.cs",
+            "swift": "main.swift",
+            "r": "main.r",
+            "ruby": "main.rb",
+            "c": "main.c",
+            "c++": "main.cpp",
+            "matlab": "main.m",
+            "typescript": "main.ts",
+            "scala": "main.scala",
+            "sql": "main.sql",
+            "html": "index.html",
+            "css": "style.css",
+            "nosql": "main.nosql",
+            "rust": "main.rs",
+            "perl": "main.pl",
+        }
+        if langcode not in support_langs and filename is None:
+            raise Exception(
+                f"Language {langcode} not supported, please set filename manually."
+            )
+
+        filename = (
+            support_langs.get(langcode, filename) if filename is None else filename
+        )
         input_data_struct = [
             [
                 [
                     "qACoKe",
-                    json.dumps(["", 5, code, [[filename, code]]]),
+                    json.dumps(
+                        [kwargs.get("instructions", ""), 5, code, [[filename, code]]]
+                    ),
                     None,
                     "generic",
                 ]

--- a/bardapi/core.py
+++ b/bardapi/core.py
@@ -481,6 +481,58 @@ class Bard:
         self._reqid += 100000
         return url
 
+    def export_replit(self, code: str, filename: str = "main.py", **kwargs):
+        """
+        Get Export URL to repl.it from code
+
+        Example:
+        >>> token = 'xxxxxxxxxx'
+        >>> bard = Bard(token=token)
+        >>> bard_code = bard.get_answer("make python code to print hello world")['code']
+        >>> url = bard.export_replit(bard_code, filename="main.py") # python code
+
+        Args:
+            code (str): code to export
+            filename (str): filename for code language
+        Returns:
+            string: export URL to create repl
+        """
+        params = {
+            "rpcids": "qACoKe",
+            "source-path": kwargs.get("source_path", "/"),
+            "bl": "boq_assistant-bard-web-server_20230718.13_p2",
+            "_reqid": str(self._reqid),
+            "rt": "c",
+        }
+        input_data_struct = [
+            [
+                [
+                    "qACoKe",
+                    json.dumps(["", 5, code, [[filename, code]]]),
+                    None,
+                    "generic",
+                ]
+            ]
+        ]
+        data = {
+            "f.req": json.dumps(input_data_struct),
+            "at": self.SNlM0e,
+        }
+
+        resp = self.session.post(
+            "https://bard.google.com/_/BardChatUi/data/batchexecute",
+            params=params,
+            data=data,
+        )
+
+        resp_dict = json.loads(resp.content.splitlines()[3])
+        print(resp_dict)
+        url = json.loads(resp_dict[0][2])[0]
+        # increment request ID
+        self._reqid += 100000
+
+        return url
+
     def _get_snim0e(self) -> str:
         """
         Get the SNlM0e value from the Bard API response.


### PR DESCRIPTION
## Description
This pull request aims to add a new feature that enables users to obtain an export URL to repl.it directly from their code.

## Related Issue
By myself

## Motivation and Context
The addition of this feature is necessary to provide users with a convenient way to export their code to repl.it without having to manually copy and paste it. It will streamline the workflow for users who frequently use repl.it for testing and sharing their code.

## How Has This Been Tested?
I have manually tested this feature on the development environment

## Screenshots (if appropriate):
![image](https://github.com/dsdanielpark/Bard-API/assets/24667698/909cc5eb-73af-4305-b358-bc08fcc4402d)

