### PR TITLE
Ensure the order of image urls

### DIFF
--- a/bardapi/core.py
+++ b/bardapi/core.py
@@ -154,7 +154,7 @@ class Bard:
                     "text_query": str,
                     "choices": list,
                     "links": list,
-                    "images": set,
+                    "images": list,
                     "program_lang": str,
                     "code": str,
                     "status_code": int
@@ -219,12 +219,12 @@ class Bard:
         resp_json = json.loads(resp_dict)
 
         # [Optional] gather image links
-        images = set()
+        images = list()
         try:
             if len(resp_json) >= 3:
                 nested_list = resp_json[4][0][4]
                 for img in nested_list:
-                    images.add(img[0][0][0])
+                    images.append(img[0][0][0])
         except (IndexError, TypeError, KeyError):
             pass
 
@@ -461,7 +461,7 @@ class Bard:
                     "text_query": str,
                     "choices": list,
                     "links": list,
-                    "images": set,
+                    "images": list,
                     "program_lang": str,
                     "code": str,
                     "status_code": int

--- a/bardapi/core_async.py
+++ b/bardapi/core_async.py
@@ -143,7 +143,7 @@ class BardAsync:
                     "text_query": str,
                     "choices": list,
                     "links": list
-                    "images": set,
+                    "images": list,
                     "program_lang": str,
                     "code": str,
                     "status_code": int
@@ -210,12 +210,12 @@ class BardAsync:
 
         # [Optional] Gather image links
         try:
-            images = set()
+            images = list()
             if len(resp_json) >= 3:
                 if len(resp_json[4][0]) >= 4 and resp_json[4][0][4] is not None:
                     for img in resp_json[4][0][4]:
                         try:
-                            images.add(img[0][0][0])
+                            images.append(img[0][0][0])
                         except Exception as e:
                             # TODO:
                             #  handle exception using logging instead
@@ -584,7 +584,7 @@ class BardAsync:
                     "text_query": str,
                     "choices": list,
                     "links": list,
-                    "images": set,
+                    "images": list,
                     "program_lang": str,
                     "code": str,
                     "status_code": int

--- a/bardapi/core_cookies.py
+++ b/bardapi/core_cookies.py
@@ -138,7 +138,7 @@ class BardCookies(Bard):
                     "text_query": str,
                     "choices": list,
                     "links": list
-                    "images": set,
+                    "images": list,
                     "program_lang": str,
                     "code": str,
                     "status_code": int
@@ -202,7 +202,7 @@ class BardCookies(Bard):
                     "text_query": str,
                     "choices": list,
                     "links": list,
-                    "images": set,
+                    "images": list,
                     "program_lang": str,
                     "code": str,
                     "status_code": int
@@ -398,7 +398,7 @@ class BardAsyncCookies(BardAsync):
                     "text_query": str,
                     "choices": list,
                     "links": list
-                    "images": set,
+                    "images": list,
                     "program_lang": str,
                     "code": str,
                     "status_code": int
@@ -475,7 +475,7 @@ class BardAsyncCookies(BardAsync):
                     "text_query": str,
                     "choices": list,
                     "links": list,
-                    "images": set,
+                    "images": list,
                     "program_lang": str,
                     "code": str,
                     "status_code": int

--- a/documents/README_DEV.md
+++ b/documents/README_DEV.md
@@ -195,7 +195,7 @@ from bardapi import Bard
 bard = Bard(token='xxxxxxxx')
 res = bard.get_answer("Find me an image of the main entrance of Stanford University.")
 res['links'] # Get image links (list)
-res['images'] # Get images (set)
+res['images'] # Get images (list)
 ```
 
 <br>

--- a/func_test.ipynb
+++ b/func_test.ipynb
@@ -51,7 +51,7 @@
     "bard = Bard(token=token)\n",
     "res = bard.get_answer(\"Find me an image of the main entrance of Stanford University.\")\n",
     "res['links'] # Get image links (list)\n",
-    "res['images'] # Get images (set)"
+    "res['images'] # Get images (list)"
    ]
   },
   {
@@ -64,7 +64,7 @@
     "bard = Bard(token=token)\n",
     "res = bard.get_answer(\"Find me an image of the main entrance of Stanford University.\")\n",
     "res['links'] # Get image links (list)\n",
-    "res['images'] # Get images (set)"
+    "res['images'] # Get images (list)"
    ]
   },
   {

--- a/translate_to/asyncio_core.py
+++ b/translate_to/asyncio_core.py
@@ -153,11 +153,11 @@ class Bard:
         if not resp_dict:
             return {"content": f"Response Error: {resp_text}."}
         resp_json = json.loads(resp_dict)
-        images = set()
+        images = list()
         if len(resp_json) >= 3:
             if len(resp_json[4][0]) >= 4 and resp_json[4][0][4] is not None:
                 for img in resp_json[4][0][4]:
-                    images.add(img[0][0][0])
+                    images.append(img[0][0][0])
         parsed_answer = json.loads(resp_dict)
         if self.language is not None and self.language not in ALLOWED_LANGUAGES:
             translator_to_lang = GoogleTranslator(source="auto", target=self.language)

--- a/translate_to/core_async.py
+++ b/translate_to/core_async.py
@@ -118,12 +118,12 @@ class BardAsync:
         resp_json = json.loads(resp_dict)
 
         # Gather image links
-        images = set()
+        images = list()
         if len(resp_json) >= 3:
             if len(resp_json[4][0]) >= 4 and resp_json[4][0][4] is not None:
                 for img in resp_json[4][0][4]:
                     try:
-                        images.add(img[0][0][0])
+                        images.append(img[0][0][0])
                     except Exception as e:
                         # TODO:
                         #  handle exception using logging instead


### PR DESCRIPTION
## Description
I changed the type of the "images" variable from set to list, to ensure the order of urls.  
I encountered a problem of inconsistency of the order of images so I made this change.   
  
\*adding to the change above, I fixed a wrong description of a type of "images" response in ask_about_image().
<!--- Describe your changes in detail -->

## Related Issue
#178 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
I encountered the problem when I tried to match the image descriptions in the reponse and image urls.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?  
I tested the get_answer() function with my machine below.  
* Windows 11 Pro 22H2 (latest update applied)
* Python 3.11.3
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):


Thank you once again to all the contributors. Your efforts are greatly appreciated!
