### PR TITLE
Added missing imports that would cause error when running script

### DIFF
--- a/bardapi/core.py
+++ b/bardapi/core.py
@@ -6,6 +6,7 @@ import random
 import re
 import string
 import uuid
+import requests
 
 # Third-party imports
 from langdetect import detect

--- a/bardapi/models/tools/map.py
+++ b/bardapi/models/tools/map.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List, Tuple
 
 from bardapi.models.user_content import UserContent
 


### PR DESCRIPTION
I welcome the overall code refactoring and new features. However, please make sure to conduct QA. Before making a PR, please check the entire functionality by adding it to https://github.com/dsdanielpark/Bard-API/blob/main/func_test.ipynb. Due to various reasons, I couldn't implement test mocking code. I also welcome anyone who can provide test mocking and refactoring. But please keep the existing method names and examples. While I aim to accept PRs as quickly as possible, they may be rejected if QA is not correct.

<!--- Provide a general summary of your changes in the Title above -->
# BARD-API Pull Request Template
Added missing imports that were causing the following errors when running the script:

```
  File "/opt/homebrew/Caskroom/miniconda/base/envs/pyp/lib/python3.11/site-packages/bardapi/models/tools/map.py", line 6, in <module>
    class BardMapsPoint:
  File "/opt/homebrew/Caskroom/miniconda/base/envs/pyp/lib/python3.11/site-packages/bardapi/models/tools/map.py", line 58, in BardMapsPoint
    def title(self) -> Tuple[str, str]:
                       ^^^^^
NameError: name 'Tuple' is not defined. Did you mean: 'tuple'?
```

```
 File "/opt/homebrew/Caskroom/miniconda/base/envs/pyp/lib/python3.11/site-packages/bardapi/models/tools/map.py", line 140, in BardMapsDirections
    def sections(self) -> List[BardMapsRoadSection]:
                          ^^^^
NameError: name 'List' is not defined. Did you mean: 'list'?
```

```
  File "/opt/homebrew/Caskroom/miniconda/base/envs/pyp/lib/python3.11/site-packages/bardapi/__init__.py", line 4, in <module>
    from bardapi.core import Bard
  File "/opt/homebrew/Caskroom/miniconda/base/envs/pyp/lib/python3.11/site-packages/bardapi/core.py", line 39, in <module>
    class Bard:
  File "/opt/homebrew/Caskroom/miniconda/base/envs/pyp/lib/python3.11/site-packages/bardapi/core.py", line 49, in Bard
    session: Optional[requests.Session] = None,
                      ^^^^^^^^
NameError: name 'requests' is not defined
```


## Description
Added basic imports from `typing`

Thank you once again to all the contributors. Your efforts are greatly appreciated!
