### PR TITLE
Remove `proxies` argument for async client

### DIFF
--- a/bardapi/core_async.py
+++ b/bardapi/core_async.py
@@ -215,7 +215,6 @@ class BardAsync:
             params=params,
             data=data,
             timeout=self.timeout,
-            proxies=self.proxies,
             follow_redirects=True,
             headers=SESSION_HEADERS,
             cookies=self.cookie_dict,
@@ -367,7 +366,6 @@ class BardAsync:
             params=params,
             data=data,
             timeout=self.timeout,
-            proxies=self.proxies,
         )
 
         # Post-processing of response
@@ -453,7 +451,6 @@ class BardAsync:
             params=params,
             data=data,
             timeout=self.timeout,
-            proxies=self.proxies,
         )
         # Post-processing of response
         resp_dict = json.loads(resp.content.splitlines()[3])
@@ -562,7 +559,6 @@ class BardAsync:
             params=params,
             data=data,
             timeout=self.timeout,
-            proxies=self.proxies,
         )
 
         resp_dict = json.loads(resp.content.splitlines()[3])
@@ -678,7 +674,6 @@ class BardAsync:
             "https://bard.google.com/_/BardChatUi/data/assistant.lamda.BardFrontendService/StreamGenerate",
             params=params,
             data=data,
-            proxies=self.proxies,
         )
 
         # Post-processing of response


### PR DESCRIPTION
## Description
- remove arg `proxies`

## Related Issue
- https://github.com/dsdanielpark/Bard-API/issues/190

## Motivation and Context
- remove arg `proxies` in async client (should have been already handled during init)
- https://www.python-httpx.org/advanced/

## How Has This Been Tested?
Tested by pip installing branch, and then run sample code (check screenshots below)
```
pip install git+ssh://git@github.com/jjkoh95/Bard-API.git@remove-proxies-arg
```

## Screenshots (if appropriate):
![image](https://github.com/dsdanielpark/Bard-API/assets/17573679/872f5f5d-8378-4e2e-9781-3c2a75a1374d)
![image](https://github.com/dsdanielpark/Bard-API/assets/17573679/3b26398d-2961-4437-b45f-0df6fc234f90)

